### PR TITLE
Fixed changed files with spaces in their names

### DIFF
--- a/libgitg/gitg-commit.c
+++ b/libgitg/gitg-commit.c
@@ -307,7 +307,7 @@ add_files (GitgCommit  *commit,
 
 	while ((line = *buffer++) != NULL)
 	{
-		gchar **parts = g_strsplit_set (line, " \t", 0);
+		gchar **parts = g_strsplit_set (line, " \t", 6);
 		guint len = g_strv_length (parts);
 
 		if (len < 6)


### PR DESCRIPTION
This bug causes staging (of changed files with spaces in their names) to fail, and commits of these files (when staged manually) to segfault.