### PR TITLE
gdk_window_get_pointer is deprecated compilation error

### DIFF
--- a/gitg/gitg-commit-view.c
+++ b/gitg/gitg-commit-view.c
@@ -1114,11 +1114,16 @@ get_info_at_pointer (GitgCommitView    *view,
 	gint height;
 	gint buf_x;
 	gint buf_y;
+	GdkDeviceManager *device_manager;
+	GdkDevice *pointer;
+
 
 	/* Get where the pointer really is. */
 	GdkWindow *win = gtk_text_view_get_window (textview, GTK_TEXT_WINDOW_TEXT);
 
-	gdk_window_get_pointer (win, &x, &y, NULL);
+	device_manager = gdk_display_get_device_manager (gdk_window_get_display (win));
+	pointer = gdk_device_manager_get_client_pointer (device_manager);
+	gdk_window_get_device_position (win, pointer, &x, &y, NULL);
 
 	width = gdk_window_get_width (win);
 	height = gdk_window_get_height (win);
@@ -1237,11 +1242,16 @@ gutter_event (GtkWidget      *widget,
 	GitgDiffLineType line_type;
 	GtkSourceGutter *gutter;
 	GtkSourceGutterRenderer *renderer_at_pos;
+	GdkDeviceManager *device_manager;
+	GdkDevice *pointer;
+
 
 	/* Get where the pointer really is. */
 	GdkWindow *win = gtk_text_view_get_window (textview, GTK_TEXT_WINDOW_LEFT);
 
-	gdk_window_get_pointer (win, &x, &y, NULL);
+	device_manager = gdk_display_get_device_manager (gdk_window_get_display (win));
+	pointer = gdk_device_manager_get_client_pointer (device_manager);
+	gdk_window_get_device_position (win, pointer, &x, &y, NULL);
 
 	width = gdk_window_get_width (win);
 	height = gdk_window_get_height (win);

--- a/gitg/gitg-dnd.c
+++ b/gitg/gitg-dnd.c
@@ -328,7 +328,7 @@ create_revision_drag_icon (GtkTreeView  *tree_view,
 	gint height;
 
 	pango_layout_get_pixel_size (layout, &width, &height);
-	
+
 	cairo_surface_t *surface = cairo_image_surface_create (CAIRO_FORMAT_ARGB32, width + 4, height + 4);
 	cairo_t *context = cairo_create (surface);
 
@@ -377,10 +377,10 @@ begin_drag (GtkWidget   *widget,
 	gint hot_x;
 	gint hot_y;
 	GitgCellRendererPath *cell;
-	GitgRef *ref = get_ref_at_pos (tree_view, 
-	                               (gint)data->x, 
-	                               (gint)data->y, 
-	                               &hot_x, 
+	GitgRef *ref = get_ref_at_pos (tree_view,
+	                               (gint)data->x,
+	                               (gint)data->y,
+	                               &hot_x,
 	                               &hot_y,
 	                               &cell,
 	                               NULL);
@@ -472,9 +472,9 @@ begin_drag (GtkWidget   *widget,
 static void
 update_highlight (GitgDndData *data, gint x, gint y)
 {
-	GitgRef *ref = get_ref_at_pos (data->tree_view, 
-	                               x, 
-	                               y, 
+	GitgRef *ref = get_ref_at_pos (data->tree_view,
+	                               x,
+	                               y,
 	                               NULL,
 	                               NULL,
 	                               NULL,
@@ -512,8 +512,14 @@ vertical_autoscroll (GitgDndData *data)
 	gint y;
 	gint offset;
 	gfloat value;
+	GdkDeviceManager *device_manager;
+	GdkDevice *pointer;
 
-	gdk_window_get_pointer (gtk_tree_view_get_bin_window (data->tree_view), NULL, &y, NULL);
+	GdkWindow *win = gtk_tree_view_get_bin_window (data->tree_view);
+
+	device_manager = gdk_display_get_device_manager (gdk_window_get_display (win));
+	pointer = gdk_device_manager_get_client_pointer (device_manager);
+	gdk_window_get_device_position (win, pointer, NULL, &y, NULL);
 	gtk_tree_view_convert_bin_window_to_tree_coords (data->tree_view, 0, y, NULL, &y);
 
 	gtk_tree_view_get_visible_rect (data->tree_view, &visible_rect);
@@ -545,8 +551,8 @@ add_scroll_timeout (GitgDndData *data)
 {
 	if (data->scroll_timeout == 0)
 	{
-		data->scroll_timeout = g_timeout_add (50, 
-		                                      (GSourceFunc)vertical_autoscroll, 
+		data->scroll_timeout = g_timeout_add (50,
+		                                      (GSourceFunc)vertical_autoscroll,
 		                                      data);
 	}
 }


### PR DESCRIPTION
This branch is pretty differs from your github master, but it differs by only one commit from [git.gnome.org](git://git.gnome.org/gitg master) repo. [This last commit](https://github.com/saks/gitg/commit/5d2473acf971c31fe56ac0a058bea86c6faa90d8) - fixes error during compilation:

```
  CC     gitg-commit-view.o
gitg-commit-view.c: In function ‘get_info_at_pointer’:
gitg-commit-view.c:1121:2: error: ‘gdk_window_get_pointer’ is deprecated (declared at /usr/include/gtk-3.0/gdk/gdkwindow.h:715): Use 'gdk_window_get_device_position' instead [-Werror=deprecated-declarations]
gitg-commit-view.c: In function ‘gutter_event’:
gitg-commit-view.c:1244:2: error: ‘gdk_window_get_pointer’ is deprecated (declared at /usr/include/gtk-3.0/gdk/gdkwindow.h:715): Use 'gdk_window_get_device_position' instead [-Werror=deprecated-declarations]
cc1: all warnings being treated as errors
make[2]: *** [gitg-commit-view.o] Error 1
make[2]: Leaving directory `/home/saks/distr/linux/gitg/gitg'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory `/home/saks/distr/linux/gitg'
make: *** [all] Error 2

```

could you apply this fix to upstream repo or fix this issue in a better way?